### PR TITLE
Disable url escape

### DIFF
--- a/router_engine.go
+++ b/router_engine.go
@@ -23,6 +23,8 @@ func NewEngine(cfg config.ServiceConfig, logger logging.Logger, w io.Writer) *gi
 	engine.RedirectTrailingSlash = true
 	engine.RedirectFixedPath = true
 	engine.HandleMethodNotAllowed = true
+	engine.UnescapePathValues = false
+	engine.UseRawPath = true
 
 	if err := httpsecure.Register(cfg.ExtraConfig, engine); err != nil {
 		logger.Warning(err)


### PR DESCRIPTION
By default, krakenD escapes URLs before forwarding to backend.
This is problematic with uniconfig and unistore where a URL e.g.

http://10.24.100.2/api/uniconfig/data/network-topology:network-topology/topology=uniconfig/node=lab-vmx1/frinx-uniconfig-topology:configuration/junos-conf-root:configuration/junos-conf-policy-options:policy-options/community=RT_31655%3A19501

would be sent to backend as

.../community=RT_31655:19501

but that is not valid for Restconf and such request would fail.

Preserve exact URL when forwarding to backend.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>